### PR TITLE
Typography & layout style updates

### DIFF
--- a/app/about.html
+++ b/app/about.html
@@ -31,6 +31,7 @@
 
 	<!-- Color the status bar on mobile devices -->
 	<meta name="theme-color" content="#263238">
+	<script src="./dist/js/bundle.js"></script>
 </head>
 
 <body>

--- a/app/index.html
+++ b/app/index.html
@@ -64,11 +64,11 @@
 	<!-- nav ends -->
 
 	<!-- hero starts -->
-	<section class="hero is-primary is-bold is-medium">
+	<section class="hero is-primary is-bold">
 		<div class="hero-body">
 			<div class="container">
 				<div class="columns">
-					<div class="column valign" style="display: flex">
+					<div class="column valign">
 						<div class="is-middle">
 							<h1 class="title is-1">Become a Vue Master</h1>
 							<h2 class="subtitle is-3">Learn with us weekly</h2>
@@ -103,12 +103,10 @@
 	<!-- news starts -->
 	<section class="section">
 		<div class="container">
-			<div class="columns">
-				<div class="column is-two-thirds valign">
-					<div class="is-bottom">
-						<h2 class="title is-2 blue">VueMastery Weekly - 1</h2>
+			<div class="columns article-object">
+				<div class="column is-two-thirds">
+						<h2 class="title is-2 is-spaced blue">VueMastery Weekly - 1</h2>
 						<p class="subtitle is-4">Welcome to our first issue. This week we will cover a lot. You should read everything and also listen to our podcast. We'll also tell you more stuff about stuff and stuff.</p>
-					</div>
 				</div>
 				<div class="column">
 					<div class="box content">
@@ -122,59 +120,64 @@
 				</div>
 			</div>
 		</div>
-		<hr>
+
 		<div class="container">
 
-			<!-- Media component -->
-			<article class="columns">
+			<!-- Article component -->
+			<article class="columns article-object">
 				<div class="column is-two-thirds">
-					<span class="tag">Opinion</span>
 					<a href="javascript:;">
-						<h3 class="title is-3">How to: Vue Router</h3>
+						<h3 class="title is-3 is-spaced">How to: Vue Router</h3>
+						<p class="subtitle">Description of article goes here and describes what the reader can expect about the article and stuff and more and even more stuff.</p>
+						<span class="tag">Opinion</span>
+						<span>by</span>
+						<span>Michele Gorsecht</span>
 					</a>
-					<p class="subtitle">Description of article goes here and describes what the reader can expect about the article and stuff and more and even more stuff.</p>
-					<b>By:&nbsp;</b><span>Michele Gorsecht</span>
 				</div>
 				<div class="column is-one-quarter">
-					<figure class="image is-3by2">
-						<img src="https://via.placeholder.com/480x320" alt="">
-					</figure>
-				</div>
-			</article>
-			<!--/ End media component -->
-			<hr>
-			<!-- Media component -->
-			<article class="columns">
-				<div class="column is-two-thirds">
-					<span class="tag">Opinion</span>
-					<a href="javscript:;">
-						<h3 class="title is-3">Vuex State Management</h3>
-					</a>
-					<p class="subtitle">Description of article goes here and describes what the reader can expect about the article and stuff and more and even more stuff.</p>
-					<b>By:&nbsp;</b><span>Adrian Vargana</span>
-				</div>
-				<div class="column is-one-quarter">
-				</div>
-			</article>
-			<!--/ End media component -->
-			<hr>
-			<!-- Media component -->
-			<article class="columns">
-				<div class="column is-two-thirds">
-					<span class="tag">Tutorial</span>
 					<a href="javascript:;">
-						<h3 class="title is-3">VueConf Workshops</h3>
+						<figure class="image is-3by2">
+							<img src="https://via.placeholder.com/480x320" alt="">
+						</figure>
 					</a>
-					<p class="subtitle">Description of article goes here and describes what the reader can expect about the article and stuff and more and even more stuff.</p>
-					<b>By:&nbsp;</b><span>Evan You</span>
-				</div>
-				<div class="column is-one-quarter">
-					<figure class="image is-3by2">
-						<img src="https://via.placeholder.com/480x320" alt="">
-					</figure>
 				</div>
 			</article>
-			<!--/ End media component -->
+			<!--/ End article component -->
+			<!-- Article component -->
+			<article class="columns article-object">
+				<div class="column is-two-thirds">
+					<a href="javascript:;">
+						<h3 class="title is-3 is-spaced">Vuex State Management</h3>
+						<p class="subtitle">Description of article goes here and describes what the reader can expect about the article and stuff and more and even more stuff.</p>
+						<span class="tag">Opinion</span>
+						<span>by</span>
+						<span>Adrian Vargana</span>
+					</a>
+				</div>
+				<div class="column is-one-quarter">
+				</div>
+			</article>
+			<!--/ End article component -->
+			<!-- Article component -->
+			<article class="columns article-object">
+				<div class="column is-two-thirds">
+					<a href="javascript:;">
+						<h3 class="title is-3 is-spaced">VueConf Workshops</h3>
+						<p class="subtitle">Description of article goes here and describes what the reader can expect about the article and stuff and more and even more stuff.</p>
+						<span class="tag">Tutorial</span>
+						<span>by</span>
+						<span>Evan You</span>
+					</a>
+				</div>
+				<div class="column is-one-quarter">
+					<a href="javascript:;">
+						<figure class="image is-3by2">
+							<img src="https://via.placeholder.com/480x320" alt="">
+						</figure>
+					</a>
+				</div>
+			</article>
+			<!--/ End article component -->
 		</div>
 	</section>
 

--- a/app/scss/_variables.scss
+++ b/app/scss/_variables.scss
@@ -34,6 +34,9 @@ $light: $white-ter !default
 $dark: $grey-darker !default
 
 $title-color: $primary;
+$subtitle-color: $grey-darker;
+$navbar-item-color: $blue;
+$navbar-item-hover-background-color: transparent;
 
 // Typography
 

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -6,6 +6,10 @@
 	margin: $gap/2 0;
 }
 
+.navbar-item {
+	font-weight: 700;
+}
+
 // BOX
 .box {
 	padding: $gap;
@@ -14,6 +18,12 @@
 // LEVEL
 .level .field {
 	margin-bottom: 0;
+}
+
+// ARTICLE
+.article-object {
+	border-bottom: solid 1px $grey-lighter;
+	padding: $gap 0;
 }
 
 // UTILITIES

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,8 +11,7 @@ module.exports = {
 	output: {
 		path: path.resolve('./dist/'),
 		filename: 'js/bundle.js',
-		publicPath: '/',
-		libraryTarget: 'umd',
+		publicPath: '/'
 	},
 	module: {
 		devtool: 'source-map',
@@ -68,6 +67,8 @@ module.exports = {
 			from: './robots.txt'
 		},{
 			from: './favicon.ico'
+		},{
+			from: './'
 		},{
 			from: './img/**/*',
 			to: './'


### PR DESCRIPTION
✅ 1) In the nav bar, let's do the `color` of the text as navy blue
✅ 2) The hero banner is too tall; we want viewers to see some content immediately, before scrolling. So if it's `is-large` now let's change it to `is-medium`
✅ 3) "VueMastery Weeky - 1" we'd like to see closer to the top of that section. 
❓ 4) The subtitle text we'd like to see vertically aligned in that same section, versus just below the title
✅ 5) The `color` of the subtitles, I'd like to see a darker gray - closer to Medium.com's gray - the higher contrast is more readable
✅ 6) We'd like more `padding-bottom` on the titles of the stories, so the subtitle isn't as close to the titles
✅ 7) Instead of the tags for "opinion" "tutorial" etc being separate and at the top-left of their story, let's make the tag and the author into one visual element. So it reads more like: [Opinion] by Michele Gorsecht (edited)